### PR TITLE
hotfix for v2-app fix #18 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG PYTHON2_IMG="saagie/python:2.7.202004.82"
-ARG PYTHON3_IMG="saagie/python:3.6.202004.82"
+ARG PYTHON2_IMG="saagie/python:2.7.202004.83"
+ARG PYTHON3_IMG="saagie/python:3.6.202004.83"
 
 # FIXME should use a minimal image and add libs after + update to latest available
 ARG BASE_CONTAINER="jupyter/scipy-notebook:c7fb6660d096"

--- a/requirements_pip2.txt
+++ b/requirements_pip2.txt
@@ -2,6 +2,7 @@
 # ipywidgets==7.0.5
 # Libs not present in saagie/python:2.7 images but previously in saagie/jupyter-python-nbk image.
 dask==0.16.0
+llvmlite==0.31.0
 fastparquet==0.1.5
 protobuf==3.6.1
 vega==0.4.4


### PR DESCRIPTION
This PR close #18 

llvmlite (https://pypi.org/project/llvmlite/) which is a requirement for fastparquet wasn't fixed and since 0.32.0 has drop support for python 2.7 so need to be fixed to 0.31.0 (https://pypi.org/project/llvmlite/0.31.0/)

Moreover use latest saagie/python Docker images (saagie/python:2.7.202004.83 & saagie/python:3.6.202004.83)