### PR TITLE
V2 app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG PYTHON2_IMG="saagie/python:2.7.202004.83"
-ARG PYTHON3_IMG="saagie/python:3.6.202004.83"
+ARG PYTHON2_IMG="saagie/python:2.7.202005.84"
+ARG PYTHON3_IMG="saagie/python:3.6.202005.84"
 
 # FIXME should use a minimal image and add libs after + update to latest available
 ARG BASE_CONTAINER="jupyter/scipy-notebook:c7fb6660d096"
@@ -41,17 +41,17 @@ USER $NB_USER
 RUN jupyter kernelspec remove -f python3
 
 # Update conda to latest version
-RUN conda update -n root conda \
-    && conda clean -afy
+#RUN conda update -n root conda \
+#    && conda clean -afy
 
 # Install python2.7 and 3.6 environments
 RUN conda create -n py27 python=2.7 \
     && bash -c "source activate py27 && conda install notebook ipykernel -y && ipython kernel install --user --name py27 --display-name 'Python 2.7'" \
-    && conda clean -afy
+    && conda clean -a
 # seems there's sometimesa problem with pyzmq so need to reinstall it...
 RUN conda create -n py36 python=3.6 \
     && bash -c "source activate py36 && pip uninstall pyzmq -y && pip install pyzmq && conda install notebook ipykernel -y && ipython kernel install --user --name py36 --display-name 'Python 3.6'" \
-    && conda clean -afy \
+    && conda clean -a \
     && rm -rf ~/.cache/pip
 
 # TODO check if all necessary seems there are duplicate from jupyter/scipy image
@@ -65,11 +65,12 @@ COPY --from=PYTHON2 /requirements.txt ./requirements_python2.txt
 COPY requirements_pip2.txt requirements_pip2.txt
 RUN conda install -n py27 --quiet --yes --file requirements_conda2.txt \
     && . activate py27 \
-    && python -m pip install --no-cache-dir -r requirements_python2.txt \
     && python -m pip install --no-cache-dir -r requirements_pip2.txt \
-    && conda deactivate \
-    && conda clean -afy \
+    && python -m pip install --no-cache-dir -r requirements_python2.txt \
+    && source deactivate \
+    && conda clean -a\
     && rm -rf ~/.cache/pip
+
 # Add libs for python 3.6 env
 #     inherited from saagie/python:3.6 image
 #     installed via pip only
@@ -81,12 +82,12 @@ RUN conda install -n py36 --quiet --yes --file requirements_conda3.txt \
     # Some installed library (scikit-learn) could not be removed so use --ignore-installed \
     && sed -n '/scikit-learn/p' requirements_python3.txt >> requirements_python3_ignore-installed.txt \
     && sed -i '/scikit-learn/d' requirements_python3.txt \
-    && . activate py36 \
+    &&. activate py36 \
     && python -m pip install --no-cache-dir --ignore-installed -r requirements_python3_ignore-installed.txt \
-    && python -m pip install --no-cache-dir -r requirements_python3.txt \
     && python -m pip install --no-cache-dir -r requirements_pip3.txt \
-    && conda deactivate \
-    && conda clean -afy \
+    && python -m pip install --no-cache-dir -r requirements_python3.txt \
+    && source deactivate \
+    && conda clean -a \
     && rm -rf ~/.cache/pip
 ################ Kernels / Conda envs / requirements PART ENDS #################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,6 @@ USER $NB_USER
 # Uninstall python3 kernel
 RUN jupyter kernelspec remove -f python3
 
-# Update conda to latest version
-#RUN conda update -n root conda \
-#    && conda clean -afy
 
 SHELL ["/bin/bash", "-c"]
 

--- a/requirements_conda3.txt
+++ b/requirements_conda3.txt
@@ -1,7 +1,5 @@
 hdf5==1.10.1
 python-hdfs==2.0.16
 
-#pillow==4.3.0
-#protobuf==3.6.1
-
 pycurl>=7.43,<7.44
+pykerberos>=1.2.1,<1.3

--- a/requirements_pip2.txt
+++ b/requirements_pip2.txt
@@ -1,5 +1,3 @@
-# Allows Python2 kernel inside jupyter
-# ipywidgets==7.0.5
 # Libs not present in saagie/python:2.7 images but previously in saagie/jupyter-python-nbk image.
 dask==0.16.0
 llvmlite==0.31.0

--- a/requirements_pip3.txt
+++ b/requirements_pip3.txt
@@ -1,7 +1,3 @@
-# Shoud be installed with conda
-#hdf5==1.10.1
-#python-hdfs==2.0.16
-
 pillow==4.3.0
 protobuf==3.6.1
 

--- a/requirements_pip3.txt
+++ b/requirements_pip3.txt
@@ -4,3 +4,5 @@
 
 pillow==4.3.0
 protobuf==3.6.1
+
+ConfigSpace==0.4.12


### PR DESCRIPTION
Corrects latest docker image build errors .

- do not update to latest conda 

- force ipython reinstall

- force ConfigSpace dependency lib install with fixed version

- add some comments on those tweaks

- update to latest available saagie/python images

Upgrade of Jupyter version is not part of this build yet